### PR TITLE
Update DealApproval recipe to find unpacked app

### DIFF
--- a/DealApproval/DealApproval.pkg.recipe
+++ b/DealApproval/DealApproval.pkg.recipe
@@ -66,12 +66,21 @@
             <string>PkgPayloadUnpacker</string>
          </dict>
          <dict>
+            <key>Arguments</key>
+            <dict>
+               <key>pattern</key>
+               <string>%RECIPE_CACHE_DIR%/unpack/payload/DealApproval*.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+         </dict>
+         <dict>
             <key>Processor</key>
             <string>PlistReader</string>
             <key>Arguments</key>
             <dict>
                <key>info_path</key>
-               <string>%RECIPE_CACHE_DIR%/unpack/payload/DealApproval_macOS.app/Contents/Info.plist</string>
+               <string>%found_filename%/Contents/Info.plist</string>
                <key>plist_keys</key>
                <dict>
                   <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
If the DealApproval app name changes, getting the version number from the app bundle’s Info.plist file fails. The path to the unpacked app bundle hardcoded.

This change finds the unpacked DealApproval app bundle. This can be used to locate the Info.plist file.